### PR TITLE
Buchungen bearbeiten

### DIFF
--- a/lib/blocs/account/account_bloc.dart
+++ b/lib/blocs/account/account_bloc.dart
@@ -21,7 +21,11 @@ class AccountBloc extends Bloc<AccountEvent, AccountState> {
       final Account createdAccount = await _accountRepository.createAccount(event.account);
       emit(AccountCreated(createdAccount));
     } catch (e) {
-      emit(AccountError('create_account_error'));
+      if (e.toString().contains('duplicated_account')) {
+        emit(AccountError('duplicated_account_error'));
+      } else {
+        emit(AccountError('create_account_error'));
+      }
     }
   }
 

--- a/lib/blocs/booking/booking_bloc.dart
+++ b/lib/blocs/booking/booking_bloc.dart
@@ -1,4 +1,5 @@
 import 'package:bloc/bloc.dart';
+import 'package:haushaltsbuch_budget_tracker/data/repositories/account_repository.dart';
 
 import '../../data/helper_models/booking_category_stats.dart';
 import '../../data/models/booking.dart';
@@ -9,9 +10,11 @@ part 'booking_state.dart';
 
 class BookingBloc extends Bloc<BookingEvent, BookingState> {
   final BookingRepository _bookingRepository;
+  final AccountRepository _accountRepository;
 
-  BookingBloc(this._bookingRepository) : super(BookingInitial()) {
+  BookingBloc(this._bookingRepository, this._accountRepository) : super(BookingInitial()) {
     on<CreateBooking>(_onCreateBooking);
+    on<UpdateBooking>(_onUpdateBooking);
     on<DeleteBooking>(_onDeleteBooking);
     on<LoadMonthlyBookings>(_onLoadMonthlyBookings);
     on<LoadYearlyBookings>(_onLoadYearlyBookings);
@@ -20,10 +23,20 @@ class BookingBloc extends Bloc<BookingEvent, BookingState> {
   Future<void> _onCreateBooking(CreateBooking event, Emitter<BookingState> emit) async {
     emit(BookingLoading());
     try {
-      final Booking createdBooking = await _bookingRepository.createBooking(event.booking);
-      emit(BookingCreated(createdBooking));
+      final List<Booking> createdBookings = await _bookingRepository.createBooking(event.booking);
+      _accountRepository.updateAccountBalance(createdBookings);
+      emit(BookingCreated());
     } catch (e) {
       emit(BookingError('create_booking_error'));
+    }
+  }
+
+  Future<void> _onUpdateBooking(UpdateBooking event, Emitter<BookingState> emit) async {
+    try {
+      final Booking updatedBooking = await _bookingRepository.updateBooking(event.booking);
+      emit(BookingUpdated(updatedBooking));
+    } catch (e) {
+      emit(BookingError('update_booking_error'));
     }
   }
 

--- a/lib/blocs/booking/booking_event.dart
+++ b/lib/blocs/booking/booking_event.dart
@@ -10,6 +10,14 @@ class CreateBooking extends BookingEvent {
   });
 }
 
+class UpdateBooking extends BookingEvent {
+  final Booking booking;
+
+  UpdateBooking({
+    required this.booking,
+  });
+}
+
 class DeleteBooking extends BookingEvent {
   final String bookingId;
 

--- a/lib/blocs/booking/booking_state.dart
+++ b/lib/blocs/booking/booking_state.dart
@@ -5,8 +5,7 @@ abstract class BookingState {}
 class BookingInitial extends BookingState {}
 
 class BookingCreated extends BookingState {
-  final Booking booking;
-  BookingCreated(this.booking);
+  BookingCreated();
 }
 
 class BookingUpdated extends BookingState {

--- a/lib/core/consts/repeat_number_consts.dart
+++ b/lib/core/consts/repeat_number_consts.dart
@@ -1,1 +1,2 @@
-const budgetRepetitionNumberInMonths = 60;
+const int budgetRepetitionNumberInMonths = 60;
+const int bookingRepetitionNumberInYears = 5;

--- a/lib/core/utils/bottom_sheets/update_budget_bottom_sheet.dart
+++ b/lib/core/utils/bottom_sheets/update_budget_bottom_sheet.dart
@@ -1,20 +1,21 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:haushaltsbuch_budget_tracker/features/budgets/presentation/pages/update_budget_page.dart';
 
+import '../../../blocs/category/category_bloc.dart';
 import '../../../data/enums/budget_selection_type.dart';
 import '../../../data/models/budget.dart';
 import '../../../l10n/app_localizations.dart';
-import '../../consts/route_consts.dart';
-import '../../page_arguments/update_budget_page_arguments.dart';
 import '../date_formatter.dart';
 
-void showUpdateBudgetBottomSheet(BuildContext context, Budget budget) {
-  final t = AppLocalizations.of(context);
+void showUpdateBudgetBottomSheet(BuildContext parentContext, Budget budget) {
+  final t = AppLocalizations.of(parentContext);
   showModalBottomSheet(
-    context: context,
+    context: parentContext,
     shape: const RoundedRectangleBorder(
       borderRadius: BorderRadius.vertical(top: Radius.circular(28)),
     ),
-    builder: (BuildContext context) {
+    builder: (BuildContext sheetContext) {
       return SafeArea(
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 24.0),
@@ -37,7 +38,7 @@ void showUpdateBudgetBottomSheet(BuildContext context, Budget budget) {
                   ),
                   IconButton(
                     icon: const Icon(Icons.close, size: 28),
-                    onPressed: () => Navigator.pop(context),
+                    onPressed: () => Navigator.pop(sheetContext),
                   ),
                 ],
               ),
@@ -55,21 +56,24 @@ void showUpdateBudgetBottomSheet(BuildContext context, Budget budget) {
                     ),
                     subtitle: Text(
                       '${selectionType.updateDescription(budget.category!.categoryName)} '
-                      '${selectionType == BudgetSelectionType.single ? '(${formatMonthYear(context, budget.budgetDate!)})' : ''}',
+                      '${selectionType == BudgetSelectionType.single ? '(${formatMonthYear(sheetContext, budget.budgetDate!)})' : ''}',
                       style: const TextStyle(fontSize: 12.0, color: Colors.grey),
                     ),
                     trailing: const Icon(Icons.keyboard_arrow_right_rounded, size: 24.0),
                     onTap: () {
-                      Navigator.pop(context);
-                      Navigator.pushNamed(
-                        context,
-                        updateBudgetRoute,
-                        arguments: UpdateBudgetPageArguments(budget, selectionType),
+                      Navigator.pop(sheetContext);
+                      Navigator.of(parentContext).push(
+                        MaterialPageRoute(
+                          builder: (_) => BlocProvider.value(
+                            value: parentContext.read<CategoryBloc>(),
+                            child: UpdateBudgetPage(budget: budget, budgetSelectionType: selectionType),
+                          ),
+                        ),
                       );
                     },
                   );
                 },
-                separatorBuilder: (context, index) => const Divider(height: 1),
+                separatorBuilder: (_, __) => const Divider(height: 1),
               ),
             ],
           ),

--- a/lib/data/repositories/account_repository.dart
+++ b/lib/data/repositories/account_repository.dart
@@ -1,17 +1,22 @@
 import 'package:supabase_flutter/supabase_flutter.dart';
 
+import '../../features/bookings/data/enums/booking_type.dart';
 import '../enums/account_type.dart';
 import '../models/account.dart';
+import '../models/booking.dart';
 
 class AccountRepository {
   Future<Account> createAccount(Account newAccount) async {
-    final createdAccount = await Supabase.instance.client.from('accounts').insert(newAccount.toMap()).select().single();
-    return Account.fromMap(createdAccount);
-  }
-
-  Future<List<Account>> loadAccounts() async {
-    final accounts = await Supabase.instance.client.from('accounts').select().order('account_type', ascending: true);
-    return (accounts as List).map((data) => Account.fromMap(data)).toList();
+    try {
+      final createdAccount = await Supabase.instance.client.from('accounts').insert(newAccount.toMap()).select().single();
+      return Account.fromMap(createdAccount);
+    } on PostgrestException catch (e) {
+      // Postgresql Fehlercode für unique_violation
+      if (e.code == '23505') {
+        throw Exception('duplicated_account');
+      }
+      rethrow;
+    }
   }
 
   Future<Account> updateAccount(Account account) async {
@@ -47,6 +52,11 @@ class AccountRepository {
     return Account.fromMap(deletedAccount);
   }
 
+  Future<List<Account>> loadAccounts() async {
+    final accounts = await Supabase.instance.client.from('accounts').select().order('account_type', ascending: true);
+    return (accounts as List).map((data) => Account.fromMap(data)).toList();
+  }
+
   double calculateAssets(List<Account> accounts) {
     double totalAssets = 0;
     for (Account account in accounts) {
@@ -65,5 +75,48 @@ class AccountRepository {
       }
     }
     return totalDebts;
+  }
+
+  Future<void> updateAccountBalance(List<Booking> bookings) async {
+    double totalSum = 0.0;
+    final SupabaseClient supabase = Supabase.instance.client;
+    if (bookings.isEmpty) {
+      return;
+    }
+    for (int i = 0; i < bookings.length; i++) {
+      // Wenn die Buchung in der Zukunft liegt, dann mit nächster Buchung weitermachen
+      if (bookings[i].bookingDate.isAfter(DateTime.now()) || bookings[i].bookingDate.isAtSameMomentAs(DateTime.now())) {
+        continue;
+      }
+      totalSum += bookings[i].amount;
+    }
+    if (bookings[0].bookingType == BookingType.expense) {
+      final debitAccount = await supabase.from('accounts').select('balance').eq('id', bookings[0].debitAccountId!).single();
+      await supabase
+          .from('accounts')
+          .update({'balance': debitAccount['balance'] - totalSum})
+          .eq('id', bookings[0].debitAccountId!)
+          .eq('user_id', supabase.auth.currentUser!.id);
+    } else if (bookings[0].bookingType == BookingType.income) {
+      final debitAccount = await supabase.from('accounts').select('balance').eq('id', bookings[0].debitAccountId!).single();
+      await supabase
+          .from('accounts')
+          .update({'balance': debitAccount['balance'] + totalSum})
+          .eq('id', bookings[0].debitAccountId!)
+          .eq('user_id', supabase.auth.currentUser!.id);
+    } else if (bookings[0].bookingType == BookingType.transfer) {
+      final debitAccount = await supabase.from('accounts').select('balance').eq('id', bookings[0].debitAccountId!).single();
+      final targetAccount = await supabase.from('accounts').select('balance').eq('id', bookings[0].targetAccountId!).single();
+      await supabase
+          .from('accounts')
+          .update({'balance': debitAccount['balance'] - totalSum})
+          .eq('id', bookings[0].debitAccountId!)
+          .eq('user_id', supabase.auth.currentUser!.id);
+      await supabase
+          .from('accounts')
+          .update({'balance': targetAccount['balance'] + totalSum})
+          .eq('id', bookings[0].targetAccountId!)
+          .eq('user_id', supabase.auth.currentUser!.id);
+    }
   }
 }

--- a/lib/data/repositories/booking_repository.dart
+++ b/lib/data/repositories/booking_repository.dart
@@ -1,14 +1,67 @@
 import 'package:collection/collection.dart';
 import 'package:haushaltsbuch_budget_tracker/data/helper_models/booking_category_stats.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:uuid/uuid.dart';
 
+import '../../core/consts/repeat_number_consts.dart';
 import '../../features/bookings/data/enums/booking_type.dart';
+import '../../features/bookings/data/enums/repetition_type.dart';
 import '../models/booking.dart';
 
 class BookingRepository {
-  Future<Booking> createBooking(Booking newBooking) async {
-    final createdBooking = await Supabase.instance.client.from('bookings').insert(newBooking.toMap()).select().single();
-    return Booking.fromMap(createdBooking);
+  Future<List<Booking>> createBooking(Booking newBooking) async {
+    final supabase = Supabase.instance.client;
+    if (newBooking.repetitionType == RepetitionType.none) {
+      final createdBookings = await Supabase.instance.client.from('bookings').insert(newBooking.toMap()).select();
+      return createdBookings.map<Booking>((e) => Booking.fromMap(e)).toList();
+    } else {
+      final createdBookingsMap = <Map<String, dynamic>>[];
+
+      final repetitionBookingId = const Uuid().v4();
+
+      final baseBookingMap = Map<String, dynamic>.from(
+        newBooking.toMap(),
+      )..['repetition_id'] = repetitionBookingId;
+
+      DateTime currentBookingDate = DateTime(
+        newBooking.bookingDate.year,
+        newBooking.bookingDate.month,
+        newBooking.bookingDate.day,
+      );
+
+      final DateTime endDate = DateTime(
+        currentBookingDate.year + bookingRepetitionNumberInYears,
+        currentBookingDate.month,
+        currentBookingDate.day,
+      );
+
+      while (currentBookingDate.isBefore(endDate)) {
+        createdBookingsMap.add({
+          ...baseBookingMap,
+          'booking_date': currentBookingDate.toIso8601String(),
+          'is_booked': !currentBookingDate.isAfter(DateTime(DateTime.now().year, DateTime.now().month, DateTime.now().day)),
+        });
+        currentBookingDate = RepetitionType.getNextBookingDate(currentBookingDate, newBooking.repetitionType);
+      }
+
+      final createdBookings = await supabase.from('bookings').insert(createdBookingsMap).select();
+      return createdBookings.map<Booking>((e) => Booking.fromMap(e)).toList();
+    }
+  }
+
+  Future<Booking> updateBooking(Booking booking) async {
+    final SupabaseClient supabase = Supabase.instance.client;
+    final updatedBooking = await supabase
+        .from('bookings')
+        .update(booking.toMap())
+        .eq('id', booking.id!)
+        .eq(
+          'user_id',
+          supabase.auth.currentUser!.id,
+        )
+        .select()
+        .single();
+    return Booking.fromMap(updatedBooking);
   }
 
   Future<void> deleteBooking(String bookingId) async {

--- a/lib/data/repositories/budget_repository.dart
+++ b/lib/data/repositories/budget_repository.dart
@@ -10,6 +10,7 @@ import '../models/budget.dart';
 
 class BudgetRepository {
   void createBudgets(Budget newBudget) async {
+    // TODO hier noch auf doppelte Budgets prüfen, auch dort noch repetitionId mit beachten + update Methode.
     final createdBudgets = <Map<String, dynamic>>[];
     DateTime currentBudgetDate = DateTime(DateTime.now().year, DateTime.now().month, 1);
     final budgetId = const Uuid().v4();

--- a/lib/data/repositories/category_repository.dart
+++ b/lib/data/repositories/category_repository.dart
@@ -16,11 +16,6 @@ class CategoryRepository {
     }
   }
 
-  Future<List<Category>> loadCategories() async {
-    final categories = await Supabase.instance.client.from('categories').select().order('created_at', ascending: false);
-    return (categories as List).map((data) => Category.fromMap(data)).toList();
-  }
-
   Future<Category> updateCategory(Category category) async {
     try {
       final SupabaseClient supabase = Supabase.instance.client;
@@ -46,5 +41,10 @@ class CategoryRepository {
     final deletedCategory =
         await supabase.from('categories').delete().eq('id', categoryId).eq('user_id', supabase.auth.currentUser!.id).select().single();
     return Category.fromMap(deletedCategory);
+  }
+
+  Future<List<Category>> loadCategories() async {
+    final categories = await Supabase.instance.client.from('categories').select().order('created_at', ascending: false);
+    return (categories as List).map((data) => Category.fromMap(data)).toList();
   }
 }

--- a/lib/data/repositories/goal_repository.dart
+++ b/lib/data/repositories/goal_repository.dart
@@ -4,8 +4,16 @@ import '../models/goal.dart';
 
 class GoalRepository {
   Future<Goal> createGoal(Goal newGoal) async {
-    final createdGoal = await Supabase.instance.client.from('goals').insert(newGoal.toMap()).select().single();
-    return Goal.fromMap(createdGoal);
+    try {
+      final createdGoal = await Supabase.instance.client.from('goals').insert(newGoal.toMap()).select().single();
+      return Goal.fromMap(createdGoal);
+    } on PostgrestException catch (e) {
+      // Postgresql Fehlercode für unique_violation
+      if (e.code == '23505') {
+        throw Exception('duplicated_goal');
+      }
+      rethrow;
+    }
   }
 
   Future<Goal> updateGoal(Goal goal) async {

--- a/lib/features/auth/presentation/pages/authentication_gate_page.dart
+++ b/lib/features/auth/presentation/pages/authentication_gate_page.dart
@@ -25,7 +25,7 @@ class AuthenticationGatePage extends StatelessWidget {
     if (session != null) {
       return MultiBlocProvider(
         providers: [
-          BlocProvider(create: (_) => BookingBloc(BookingRepository())),
+          BlocProvider(create: (_) => BookingBloc(BookingRepository(), AccountRepository())),
           BlocProvider(create: (_) => CategoryBloc(CategoryRepository())),
           BlocProvider(create: (_) => AccountBloc(AccountRepository())),
           BlocProvider(create: (_) => BudgetBloc(BudgetRepository())),

--- a/lib/features/bookings/data/enums/repetition_type.dart
+++ b/lib/features/bookings/data/enums/repetition_type.dart
@@ -25,6 +25,78 @@ enum RepetitionType {
         'Ende des Jahres' => RepetitionType.endOfYear,
         _ => RepetitionType.none
       };
+
+  static DateTime getNextBookingDate(
+    DateTime current,
+    RepetitionType repetitionType,
+  ) {
+    switch (repetitionType) {
+      case RepetitionType.none:
+        return current;
+
+      case RepetitionType.weekly:
+        return current.add(const Duration(days: 7));
+
+      case RepetitionType.twoWeekly:
+        return current.add(const Duration(days: 14));
+
+      case RepetitionType.beginningOfMonth:
+        return DateTime(
+          current.year,
+          current.month + 1,
+          1,
+        );
+
+      case RepetitionType.endOfMonth:
+        return DateTime(
+          current.year,
+          current.month + 2,
+          0,
+        );
+
+      case RepetitionType.monthly:
+        return DateTime(
+          current.year,
+          current.month + 1,
+          current.day,
+        );
+
+      case RepetitionType.quarterly:
+        return DateTime(
+          current.year,
+          current.month + 3,
+          current.day,
+        );
+
+      case RepetitionType.halfYearly:
+        return DateTime(
+          current.year,
+          current.month + 6,
+          current.day,
+        );
+
+      case RepetitionType.yearly:
+        return DateTime(
+          current.year + 1,
+          current.month,
+          current.day,
+        );
+
+      case RepetitionType.beginningOfYear:
+        return DateTime(
+          current.year + 1,
+          1,
+          1,
+        );
+
+      case RepetitionType.endOfYear:
+        return DateTime(
+          current.year + 1,
+          12,
+          31,
+        );
+    }
+  }
 }
 
 extension AmountTypeExtension on RepetitionType {

--- a/lib/features/bookings/presentation/pages/create_booking_page.dart
+++ b/lib/features/bookings/presentation/pages/create_booking_page.dart
@@ -21,6 +21,7 @@ import '../../../../data/models/account.dart';
 import '../../../../data/models/booking.dart';
 import '../../../../data/models/category.dart';
 import '../../../../data/models/goal.dart';
+import '../../../../data/repositories/account_repository.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../data/enums/amount_type.dart';
 import '../../data/enums/booking_type.dart';
@@ -123,11 +124,39 @@ class _CreateBookingPageState extends State<CreateBookingPage> {
     }
   }
 
+  DateTime tryParseSelectedDate() {
+    try {
+      return DateFormat(
+        '(E) dd.MM.yyyy',
+        WidgetsBinding.instance.platformDispatcher.locale.toString(),
+      ).parseStrict(_dateController.text);
+    } catch (_) {
+      return DateTime.now();
+    }
+  }
+
+  void setDateForRepetitionType() {
+    final date = tryParseSelectedDate();
+    if (_repetitionType == RepetitionType.beginningOfMonth) {
+      _dateController.text =
+          DateFormat('(E) dd.MM.yyyy', WidgetsBinding.instance.platformDispatcher.locale.toString()).format(DateTime(date.year, date.month, 1));
+    } else if (_repetitionType == RepetitionType.endOfMonth) {
+      _dateController.text =
+          DateFormat('(E) dd.MM.yyyy', WidgetsBinding.instance.platformDispatcher.locale.toString()).format(DateTime(date.year, date.month + 1, 0));
+    } else if (_repetitionType == RepetitionType.beginningOfYear) {
+      _dateController.text =
+          DateFormat('(E) dd.MM.yyyy', WidgetsBinding.instance.platformDispatcher.locale.toString()).format(DateTime(date.year, 1, 1));
+    } else if (_repetitionType == RepetitionType.endOfYear) {
+      _dateController.text =
+          DateFormat('(E) dd.MM.yyyy', WidgetsBinding.instance.platformDispatcher.locale.toString()).format(DateTime(date.year, 12, 31));
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final t = AppLocalizations.of(context);
     return BlocProvider(
-      create: (_) => BookingBloc(BookingRepository()),
+      create: (_) => BookingBloc(BookingRepository(), AccountRepository()),
       child: Builder(builder: (context) {
         return BlocListener<BookingBloc, BookingState>(
           listener: (context, state) {
@@ -172,6 +201,7 @@ class _CreateBookingPageState extends State<CreateBookingPage> {
                           onRepetitionTypeChanged: (RepetitionType newRepetitionType) {
                             setState(() {
                               _repetitionType = newRepetitionType;
+                              setDateForRepetitionType();
                             });
                           },
                         ),

--- a/lib/features/bookings/presentation/pages/update_booking_page.dart
+++ b/lib/features/bookings/presentation/pages/update_booking_page.dart
@@ -15,13 +15,7 @@ import 'package:intl/intl.dart';
 import 'package:rounded_loading_button/rounded_loading_button.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
-import '../../../../blocs/account/account_bloc.dart';
-import '../../../../blocs/account/account_event.dart';
 import '../../../../blocs/booking/booking_bloc.dart';
-import '../../../../blocs/category/category_bloc.dart';
-import '../../../../blocs/category/category_event.dart';
-import '../../../../blocs/goal/goal_bloc.dart';
-import '../../../../blocs/goal/goal_event.dart';
 import '../../../../core/consts/animation_consts.dart';
 import '../../../../core/utils/app_flushbar.dart';
 import '../../../../core/utils/dialogs/show_delete_dialog.dart';
@@ -31,8 +25,6 @@ import '../../../../data/models/booking.dart';
 import '../../../../data/models/category.dart';
 import '../../../../data/models/goal.dart';
 import '../../../../data/repositories/account_repository.dart';
-import '../../../../data/repositories/category_repository.dart';
-import '../../../../data/repositories/goal_repository.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../data/enums/amount_type.dart';
 import '../../data/enums/booking_type.dart';
@@ -117,7 +109,8 @@ class _UpdateBookingPageState extends State<UpdateBookingPage> {
       final DateTime parsedDate =
           DateFormat('(E) dd.MM.yyyy', WidgetsBinding.instance.platformDispatcher.locale.toString()).parse(_dateController.text);
 
-      final Booking newBooking = Booking(
+      final Booking updatedBooking = Booking(
+        id: widget.booking.id,
         userId: supabase.auth.currentUser!.id,
         bookingType: _bookingType, // TODO
         title: _titleController.text.trim(),
@@ -133,7 +126,7 @@ class _UpdateBookingPageState extends State<UpdateBookingPage> {
         isBooked: true, // TODO
       );
 
-      contextForBloc.read<BookingBloc>().add(CreateBooking(booking: newBooking));
+      contextForBloc.read<BookingBloc>().add(UpdateBooking(booking: updatedBooking));
     } on PostgrestException catch (_) {
       AppFlushbar.show(context, message: t.translate('database_error'));
       _updateBookingButtonController.error();
@@ -159,7 +152,7 @@ class _UpdateBookingPageState extends State<UpdateBookingPage> {
   Widget build(BuildContext context) {
     final t = AppLocalizations.of(context);
     return BlocProvider(
-      create: (_) => BookingBloc(BookingRepository()),
+      create: (_) => BookingBloc(BookingRepository(), AccountRepository()),
       child: Builder(builder: (innerContext) {
         return BlocListener<BookingBloc, BookingState>(
           listener: (context, state) {
@@ -194,7 +187,6 @@ class _UpdateBookingPageState extends State<UpdateBookingPage> {
                     );
 
                     if (confirmed == true) {
-                      // TODO hier weitermachen mit Laden von Kategorien, Konten und Ziele verbessern mit BlocProvider.value?!
                       bookingBloc.add(DeleteBooking(bookingId: widget.booking.id!));
                       navigator.pushNamedAndRemoveUntil(
                         homeRoute,
@@ -244,35 +236,29 @@ class _UpdateBookingPageState extends State<UpdateBookingPage> {
                         TitleInputField(titleController: _titleController),
                         _bookingType == BookingType.transfer
                             ? SizedBox.shrink()
-                            : BlocProvider(
-                                create: (context) => CategoryBloc(CategoryRepository())..add(LoadCategories()),
-                                child: CategorieInputField(
-                                  categorieController: _categorieController,
-                                  bookingType: _bookingType,
-                                  onCategorieChanged: (Category newCategory) {
-                                    setState(() {
-                                      _selectedCategory = newCategory;
-                                    });
-                                  },
-                                ),
+                            : CategorieInputField(
+                                categorieController: _categorieController,
+                                bookingType: _bookingType,
+                                onCategorieChanged: (Category newCategory) {
+                                  setState(() {
+                                    _selectedCategory = newCategory;
+                                  });
+                                },
                               ),
                         Row(
                           children: [
                             Expanded(
                               child: Padding(
                                 padding: EdgeInsets.only(right: _bookingType == BookingType.transfer ? 12.0 : 0.0),
-                                child: BlocProvider(
-                                  create: (context) => AccountBloc(AccountRepository())..add(LoadAccounts()),
-                                  child: AccountInputField(
-                                    accountController: _debitAccountController,
-                                    text: _bookingType == BookingType.transfer ? 'debit_account' : 'account',
-                                    showSuffixIcon: _bookingType == BookingType.transfer ? false : true,
-                                    onAccountChanged: (Account newDebitAccount) {
-                                      setState(() {
-                                        _selectedDebitAccount = newDebitAccount;
-                                      });
-                                    },
-                                  ),
+                                child: AccountInputField(
+                                  accountController: _debitAccountController,
+                                  text: _bookingType == BookingType.transfer ? 'debit_account' : 'account',
+                                  showSuffixIcon: _bookingType == BookingType.transfer ? false : true,
+                                  onAccountChanged: (Account newDebitAccount) {
+                                    setState(() {
+                                      _selectedDebitAccount = newDebitAccount;
+                                    });
+                                  },
                                 ),
                               ),
                             ),
@@ -286,34 +272,28 @@ class _UpdateBookingPageState extends State<UpdateBookingPage> {
                                 ? Expanded(
                                     child: Padding(
                                       padding: const EdgeInsets.only(left: 12.0),
-                                      child: BlocProvider(
-                                        create: (context) => AccountBloc(AccountRepository())..add(LoadAccounts()),
-                                        child: AccountInputField(
-                                          accountController: _targetAccountController,
-                                          text: 'target_account',
-                                          showSuffixIcon: _bookingType == BookingType.transfer ? false : true,
-                                          onAccountChanged: (Account newTargetAccount) {
-                                            setState(() {
-                                              _selectedTargetAccount = newTargetAccount;
-                                            });
-                                          },
-                                        ),
+                                      child: AccountInputField(
+                                        accountController: _targetAccountController,
+                                        text: 'target_account',
+                                        showSuffixIcon: _bookingType == BookingType.transfer ? false : true,
+                                        onAccountChanged: (Account newTargetAccount) {
+                                          setState(() {
+                                            _selectedTargetAccount = newTargetAccount;
+                                          });
+                                        },
                                       ),
                                     ),
                                   )
                                 : SizedBox.shrink(),
                           ],
                         ),
-                        BlocProvider(
-                          create: (context) => GoalBloc(GoalRepository())..add(LoadGoals()),
-                          child: GoalInputField(
-                            goalController: _goalController,
-                            onGoalChanged: (Goal newGoal) {
-                              setState(() {
-                                _selectedGoal = newGoal;
-                              });
-                            },
-                          ),
+                        GoalInputField(
+                          goalController: _goalController,
+                          onGoalChanged: (Goal newGoal) {
+                            setState(() {
+                              _selectedGoal = newGoal;
+                            });
+                          },
                         ),
                         // TODO implementieren, wenn Haushaltsmitglieder hinzugefügt werden: PersonInputField(personController: _personController),
                         SizedBox(height: 30.0),
@@ -322,7 +302,7 @@ class _UpdateBookingPageState extends State<UpdateBookingPage> {
                           child: AnimatedLoadingButton(
                             text: t.translate('update_booking'),
                             controller: _updateBookingButtonController,
-                            onPressed: () => _updateBooking(context),
+                            onPressed: () => _updateBooking(innerContext),
                             horizontalPadding: 12.0,
                             buttonColor: Colors.cyanAccent,
                             textColor: Colors.black87,

--- a/lib/features/bookings/presentation/widgets/cards/booking_card.dart
+++ b/lib/features/bookings/presentation/widgets/cards/booking_card.dart
@@ -1,12 +1,16 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
-import 'package:haushaltsbuch_budget_tracker/core/consts/route_consts.dart';
-import 'package:haushaltsbuch_budget_tracker/core/page_arguments/update_booking_page_arguments.dart';
 import 'package:haushaltsbuch_budget_tracker/features/bookings/data/enums/booking_type.dart';
 import 'package:haushaltsbuch_budget_tracker/l10n/app_localizations.dart';
 
+import '../../../../../blocs/account/account_bloc.dart';
+import '../../../../../blocs/booking/booking_bloc.dart';
+import '../../../../../blocs/category/category_bloc.dart';
+import '../../../../../blocs/goal/goal_bloc.dart';
 import '../../../../../core/utils/currency_formatter.dart';
 import '../../../../../data/models/booking.dart';
+import '../../pages/update_booking_page.dart';
 
 class BookingCard extends StatelessWidget {
   final Booking booking;
@@ -20,7 +24,19 @@ class BookingCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final t = AppLocalizations.of(context);
     return GestureDetector(
-      onTap: () => Navigator.pushNamed(context, updateBookingRoute, arguments: UpdateBookingPageArguments(booking)),
+      onTap: () => Navigator.of(context).push(
+        MaterialPageRoute(
+          builder: (_) => MultiBlocProvider(
+            providers: [
+              BlocProvider.value(value: context.read<BookingBloc>()),
+              BlocProvider.value(value: context.read<CategoryBloc>()),
+              BlocProvider.value(value: context.read<AccountBloc>()),
+              BlocProvider.value(value: context.read<GoalBloc>()),
+            ],
+            child: UpdateBookingPage(booking: booking),
+          ),
+        ),
+      ),
       child: Card(
         child: ClipPath(
           clipper: ShapeBorderClipper(

--- a/lib/features/bookings/presentation/widgets/list_views/yearly_booking_list.dart
+++ b/lib/features/bookings/presentation/widgets/list_views/yearly_booking_list.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_staggered_animations/flutter_staggered_animations.dart';
+import 'package:haushaltsbuch_budget_tracker/data/repositories/account_repository.dart';
 import 'package:haushaltsbuch_budget_tracker/features/bookings/presentation/widgets/cards/booking_month_overview_card.dart';
 import 'package:intl/intl.dart';
 
@@ -46,7 +47,7 @@ class _YearlyBookingListState extends State<YearlyBookingList> {
   Widget build(BuildContext context) {
     final List<String> months = getAllMonthNames('de_DE');
     return BlocProvider(
-      create: (_) => BookingBloc(BookingRepository())..add(LoadYearlyBookings(selectedYear: widget.currentSelectedYear)),
+      create: (_) => BookingBloc(BookingRepository(), AccountRepository())..add(LoadYearlyBookings(selectedYear: widget.currentSelectedYear)),
       child: BlocBuilder<BookingBloc, BookingState>(
         builder: (context, state) {
           if (state is BookingLoading) {

--- a/lib/features/budgets/presentation/pages/update_budget_page.dart
+++ b/lib/features/budgets/presentation/pages/update_budget_page.dart
@@ -2,17 +2,14 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:haushaltsbuch_budget_tracker/blocs/category/category_event.dart';
 import 'package:haushaltsbuch_budget_tracker/core/utils/currency_formatter.dart';
 import 'package:haushaltsbuch_budget_tracker/data/enums/budget_selection_type.dart';
-import 'package:haushaltsbuch_budget_tracker/data/repositories/category_repository.dart';
 import 'package:rounded_loading_button/rounded_loading_button.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../../../../blocs/budget/budget_bloc.dart';
 import '../../../../blocs/budget/budget_event.dart';
 import '../../../../blocs/budget/budget_state.dart';
-import '../../../../blocs/category/category_bloc.dart';
 import '../../../../core/consts/animation_consts.dart';
 import '../../../../core/consts/route_consts.dart';
 import '../../../../core/page_arguments/home_page_arguments.dart';
@@ -147,17 +144,14 @@ class _UpdateBudgetPageState extends State<UpdateBudgetPage> {
                     child: Column(
                       mainAxisAlignment: MainAxisAlignment.start,
                       children: [
-                        BlocProvider(
-                          create: (context) => CategoryBloc(CategoryRepository())..add(LoadCategories()),
-                          child: CategorieInputField(
-                            categorieController: _categoryController,
-                            bookingType: BookingType.expense,
-                            onCategorieChanged: (Category newCategory) {
-                              setState(() {
-                                _selectedCategory = newCategory;
-                              });
-                            },
-                          ),
+                        CategorieInputField(
+                          categorieController: _categoryController,
+                          bookingType: BookingType.expense,
+                          onCategorieChanged: (Category newCategory) {
+                            setState(() {
+                              _selectedCategory = newCategory;
+                            });
+                          },
                         ),
                         AmountInputField(
                           amountController: _budgetAmountController,

--- a/lib/features/budgets/presentation/widgets/cards/budget_card.dart
+++ b/lib/features/budgets/presentation/widgets/cards/budget_card.dart
@@ -1,13 +1,15 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_staggered_animations/flutter_staggered_animations.dart';
-import 'package:haushaltsbuch_budget_tracker/core/consts/route_consts.dart';
-import 'package:haushaltsbuch_budget_tracker/core/page_arguments/budget_bookings_page_arguments.dart';
 import 'package:percent_indicator/circular_percent_indicator.dart';
 
+import '../../../../../blocs/category/category_bloc.dart';
 import '../../../../../core/utils/currency_formatter.dart';
+import '../../../../../core/utils/slow_hero_animation.dart';
 import '../../../../../data/models/booking.dart';
 import '../../../../../data/models/budget.dart';
 import '../../../../../l10n/app_localizations.dart';
+import '../../pages/budget_bookings_page.dart';
 
 class BudgetCard extends StatelessWidget {
   final Budget budget;
@@ -39,7 +41,15 @@ class BudgetCard extends StatelessWidget {
       verticalOffset: 40.0,
       child: FadeInAnimation(
         child: GestureDetector(
-          onTap: () => Navigator.pushNamed(context, budgetBookingsRoute, arguments: BudgetBookingsPageArguments(budget, bookings)),
+          onTap: () => Navigator.push(
+            context,
+            slowHeroRoute(
+              BlocProvider.value(
+                value: context.read<CategoryBloc>(),
+                child: BudgetBookingsPage(budget: budget, bookings: bookings),
+              ),
+            ),
+          ),
           child: Card(
             child: ClipPath(
               clipper: ShapeBorderClipper(

--- a/lib/l10n/app_de.dart
+++ b/lib/l10n/app_de.dart
@@ -180,7 +180,7 @@ const Map<String, String> de = {
   'create_account_error': 'Datenbankfehler beim Erstellen des Kontos. Bitte versuchen Sie es später erneut.',
   'update_account_error': 'Datenbankfehler beim Bearbeiten des Kontos. Bitte versuchen Sie es später erneut.',
   'delete_account_error': 'Datenbankfehler beim Löschen des Kontos. Bitte versuchen Sie es später erneut.',
-  'duplicated_account_error': 'Ein Konto mit diesem Namen existiert bereits.',
+  'duplicated_account_error': 'Ein Konto mit diesem Kontoname existiert bereits.',
   'duplicated_goal_error': 'Ein Ziel mit diesem Namen existiert bereits.',
   'load_accounts_error': 'Datenbankfehler beim Laden der Konten. Bitte versuchen Sie es später erneut.',
   'create_category_error': 'Datenbankfehler beim Erstellen der Kategorie. Bitte versuchen Sie es später erneut.',

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -79,7 +79,7 @@ void main() async {
           MaterialPageRoute(
             builder: (_) => MultiBlocProvider(
               providers: [
-                BlocProvider(create: (context) => BookingBloc(BookingRepository())),
+                BlocProvider(create: (context) => BookingBloc(BookingRepository(), AccountRepository())),
                 BlocProvider(create: (context) => CategoryBloc(CategoryRepository())),
                 BlocProvider(create: (context) => AccountBloc(AccountRepository())),
                 BlocProvider(create: (context) => BudgetBloc(BudgetRepository())),
@@ -272,7 +272,7 @@ class MyApp extends StatelessWidget {
               settings: settings,
               child: MultiBlocProvider(
                 providers: [
-                  BlocProvider(create: (context) => BookingBloc(BookingRepository())),
+                  BlocProvider(create: (context) => BookingBloc(BookingRepository(), AccountRepository())),
                   BlocProvider(create: (context) => CategoryBloc(CategoryRepository())),
                   BlocProvider(create: (context) => AccountBloc(AccountRepository())),
                   BlocProvider(create: (context) => BudgetBloc(BudgetRepository())),


### PR DESCRIPTION
- Der Benutzer kann nun Einzelbuchungen bearbeiten (Serienbuchungen bearbeiten muss noch implementiert werden).
- Der Benutzer kann nun Serienbuchungen erstellen, alle Buchungen die in der Vergangenheit liegen werden auch vom entsprechenden Konto / Konten bei Transfer verbucht.
- Der Benutzer kann keine doppelten Kategorien, Ziele oder Konten mit dem gleichen Namen mehr anlegen.