### PR TITLE
Fehler bei Monats- oder Jahreswechsel behoben

### DIFF
--- a/lib/features/home/presentation/pages/home_page.dart
+++ b/lib/features/home/presentation/pages/home_page.dart
@@ -370,13 +370,17 @@ class _HomePageState extends State<HomePage> {
                       onDateChanged: (newDate, currentPeriodOfTime) {
                         setState(() {
                           _currentSelectedDate = newDate;
-                          if (currentPeriodOfTime == PeriodOfTimeType.monthly) {
-                            _currentSelectedDate = DateTime(_currentSelectedDate.year, _currentSelectedDate.month, 1);
-                            onPeriodOfTimeChanged(PeriodOfTimeType.yearly);
-                          } else {
-                            onPeriodOfTimeChanged(PeriodOfTimeType.monthly);
-                          }
+                          onPeriodOfTimeChanged(currentPeriodOfTime);
                         });
+                      },
+                      onPageChanged: (newDate, currentPeriodOfTime) {
+                        setState(() {
+                          _currentSelectedDate = newDate;
+                          onPeriodOfTimeChanged(currentPeriodOfTime);
+                        });
+                      },
+                      onPeriodOfTimeChanged: (newPeriodOfTime) {
+                        onPeriodOfTimeChanged(newPeriodOfTime);
                       },
                     ),
                   ],

--- a/lib/features/home/presentation/widgets/navigation/date_picker_bar.dart
+++ b/lib/features/home/presentation/widgets/navigation/date_picker_bar.dart
@@ -8,14 +8,18 @@ import '../../../../../l10n/app_localizations.dart';
 
 class DatePickerBar extends StatefulWidget {
   final DateTime initialDate;
-  final PeriodOfTimeType currentPeriodOfTime;
+  PeriodOfTimeType currentPeriodOfTime;
   final void Function(DateTime date, PeriodOfTimeType currentPeriodOfTime) onDateChanged;
+  final void Function(DateTime date, PeriodOfTimeType currentPeriodOfTime) onPageChanged;
+  final void Function(PeriodOfTimeType currentPeriodOfTime)? onPeriodOfTimeChanged;
 
-  const DatePickerBar({
+  DatePickerBar({
     super.key,
     required this.initialDate,
-    required this.currentPeriodOfTime,
+    this.currentPeriodOfTime = PeriodOfTimeType.monthly,
     required this.onDateChanged,
+    required this.onPageChanged,
+    required this.onPeriodOfTimeChanged,
   });
 
   @override
@@ -76,20 +80,6 @@ class _DatePickerBarState extends State<DatePickerBar> {
     return 1000 + totalMonthDiff;
   }
 
-  void _onMonthSelected(int index, DateTime currentDate) {
-    setState(() {
-      _currentIndex = index;
-      _selectedDate = _getDateFromIndex(_currentIndex, widget.currentPeriodOfTime);
-    });
-
-    _controller.animateToPage(
-      index,
-      duration: Duration(milliseconds: 300),
-      curve: Curves.easeOut,
-    );
-    widget.onDateChanged(_selectedDate, widget.currentPeriodOfTime);
-  }
-
   @override
   Widget build(BuildContext context) {
     final t = AppLocalizations.of(context);
@@ -106,7 +96,7 @@ class _DatePickerBarState extends State<DatePickerBar> {
                 _currentIndex = index;
                 _selectedDate = newDate;
                 WidgetsBinding.instance.addPostFrameCallback((_) {
-                  widget.onDateChanged(newDate, widget.currentPeriodOfTime);
+                  widget.onPageChanged(newDate, widget.currentPeriodOfTime);
                 });
               },
               itemBuilder: (context, index) {
@@ -210,7 +200,17 @@ class _DatePickerBarState extends State<DatePickerBar> {
                         widget.onDateChanged(_selectedDate, widget.currentPeriodOfTime);
                       }
                     } else {
-                      _onMonthSelected(index, currentDate);
+                      setState(() {
+                        _currentIndex = index;
+                        _selectedDate = _getDateFromIndex(_currentIndex, widget.currentPeriodOfTime);
+                      });
+
+                      _controller.animateToPage(
+                        index,
+                        duration: Duration(milliseconds: 300),
+                        curve: Curves.easeOut,
+                      );
+                      widget.onDateChanged(_selectedDate, widget.currentPeriodOfTime);
                     }
                   },
                   child: Center(
@@ -301,7 +301,10 @@ class _DatePickerBarState extends State<DatePickerBar> {
               child: TextButton(
                 onPressed: () {
                   setState(() {
-                    widget.onDateChanged(_selectedDate, widget.currentPeriodOfTime);
+                    widget.currentPeriodOfTime == PeriodOfTimeType.yearly
+                        ? widget.currentPeriodOfTime = PeriodOfTimeType.monthly
+                        : widget.currentPeriodOfTime = PeriodOfTimeType.yearly;
+                    widget.onPeriodOfTimeChanged?.call(widget.currentPeriodOfTime);
                   });
                 },
                 style: TextButton.styleFrom(overlayColor: Colors.transparent),


### PR DESCRIPTION
- Der Benutzer kann Monats- und Jahreswechsel nun durch swipen, klicken auf nächsten Monat oder Jahr oder wenn auf aktuelles Datum geklickt wird über ein DatePicker auswählen.
- Über einen Button kann der Benutzer zwischen Monat und Jahr wechseln.